### PR TITLE
Added FixFlags.All flag for logging event

### DIFF
--- a/src/log4net.ElasticSearch/Infrastructure/HttpClient.cs
+++ b/src/log4net.ElasticSearch/Infrastructure/HttpClient.cs
@@ -30,12 +30,6 @@ namespace log4net.ElasticSearch.Infrastructure
 
                 var httpResponse = (HttpWebResponse) httpWebRequest.GetResponse();
                 httpResponse.Close();
-
-                if (httpResponse.StatusCode != HttpStatusCode.Created)
-                {
-                    throw new WebException(
-                        "Failed to post {0} to {1}.".With(item.GetType().Name, uri));
-                }
             }
         }
 
@@ -68,12 +62,6 @@ namespace log4net.ElasticSearch.Infrastructure
 
                 var httpResponse = (HttpWebResponse)httpWebRequest.GetResponse();
                 httpResponse.Close();
-
-                if (httpResponse.StatusCode != HttpStatusCode.Created && httpResponse.StatusCode != HttpStatusCode.OK)
-                {
-                    throw new WebException(
-                        "Failed to post {0} to {1}.".With(postBody.ToString(), uri));
-                }
             }
         }
 

--- a/src/log4net.ElasticSearch/Models/LogEvent.cs
+++ b/src/log4net.ElasticSearch/Models/LogEvent.cs
@@ -61,6 +61,7 @@ namespace log4net.ElasticSearch.Models
 
         static logEvent Create(LoggingEvent loggingEvent)
         {
+            loggingEvent.Fix = FixFlags.All;
             var logEvent = new logEvent
             {
                 loggerName = loggingEvent.LoggerName,

--- a/src/log4net.ElasticSearch/Repository.cs
+++ b/src/log4net.ElasticSearch/Repository.cs
@@ -29,16 +29,23 @@ namespace log4net.ElasticSearch
         /// <param name="bufferSize">The BufferSize as set in the connection string details</param>
         public void Add(IEnumerable<logEvent> logEvents, int bufferSize)
         {
-            if (bufferSize <= 1)
+            try
             {
-                // Post the logEvents one at a time throught the ES insert API
-                logEvents.Do(logEvent => httpClient.Post(uri, logEvent));
+                if (bufferSize <= 1)
+                {
+                    // Post the logEvents one at a time throught the ES insert API
+                    logEvents.Do(logEvent => httpClient.Post(uri, logEvent));
+                }
+                else
+                {
+                    // Post the logEvents all at once using the ES _bulk API
+                    httpClient.PostBulk(uri, logEvents);
+                }   
             }
-            else
+            catch(Exception ex)
             {
-                // Post the logEvents all at once using the ES _bulk API
-                httpClient.PostBulk(uri, logEvents);
-            }   
+                //DO NOTHING.
+            }
         }
 
         public static IRepository Create(string connectionString)

--- a/src/log4net.ElasticSearch/Repository.cs
+++ b/src/log4net.ElasticSearch/Repository.cs
@@ -29,23 +29,16 @@ namespace log4net.ElasticSearch
         /// <param name="bufferSize">The BufferSize as set in the connection string details</param>
         public void Add(IEnumerable<logEvent> logEvents, int bufferSize)
         {
-            try
+            if (bufferSize <= 1)
             {
-                if (bufferSize <= 1)
-                {
-                    // Post the logEvents one at a time throught the ES insert API
-                    logEvents.Do(logEvent => httpClient.Post(uri, logEvent));
-                }
-                else
-                {
-                    // Post the logEvents all at once using the ES _bulk API
-                    httpClient.PostBulk(uri, logEvents);
-                }   
+                // Post the logEvents one at a time throught the ES insert API
+                logEvents.Do(logEvent => httpClient.Post(uri, logEvent));
             }
-            catch(System.Exception ex)
+            else
             {
-                //DO NOTHING.
-            }
+                // Post the logEvents all at once using the ES _bulk API
+                httpClient.PostBulk(uri, logEvents);
+            }   
         }
 
         public static IRepository Create(string connectionString)

--- a/src/log4net.ElasticSearch/Repository.cs
+++ b/src/log4net.ElasticSearch/Repository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using log4net.ElasticSearch.Infrastructure;
 using log4net.ElasticSearch.Models;
+using System;
 
 namespace log4net.ElasticSearch
 {

--- a/src/log4net.ElasticSearch/Repository.cs
+++ b/src/log4net.ElasticSearch/Repository.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using log4net.ElasticSearch.Infrastructure;
 using log4net.ElasticSearch.Models;
-using System;
 
 namespace log4net.ElasticSearch
 {
@@ -43,7 +42,7 @@ namespace log4net.ElasticSearch
                     httpClient.PostBulk(uri, logEvents);
                 }   
             }
-            catch(Exception ex)
+            catch(System.Exception ex)
             {
                 //DO NOTHING.
             }


### PR DESCRIPTION
adding FixFlags.All flag to ensure all log4net related prorperties are populated before log4net passed it to logstash. It is to fix known custom appender bug where it log4net does not populate properties like className, method name.